### PR TITLE
docs(README): Allow the Android manual linking instructions to work with Gradle 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Click on your main project file (the one that represents the `.xcodeproj`) selec
    
 #### `android/settings.gradle`
 ```groovy
-include ':@react-native-community/slider'
-project(':@react-native-community/slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
+include ':react-native-community-slider'
+project(':react-native-community-slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
 ```
 
 #### `android/app/build.gradle`
 ```groovy
 dependencies {
    ...
-   implementation project(':@react-native-community/slider')
+   implementation project(':react-native-community-slider')
 }
 ```
 


### PR DESCRIPTION
Summary:
---------

Gradle 5 introduces new rules for which characters are allowed in project names:

> You can no longer use any of the following characters in domain object names, such as project and task names: <space> / \ : < > " ? * | . You should also not use . as a leading or trailing character.

This PR removes the `/` that is now not allowed.

This means that new users who setup the library now will not be affected when upgrading to Gradle 5. Existing users will get an error message like this and will need to make the change manually:

```
* What went wrong:
A problem occurred configuring project ':@react-native-community/slider'.
> The project name '@react-native-community/slider' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/5.2/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

Test Plan:
----------

Follow the instructions and see that linking still works.