### PR TITLE
fix: add "main" field in package.json to avoid metro error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "js/Slider.js",
   "types": "typings/index.d.ts",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Currently, this is the error that shows up when trying to use the Slider in a project: 

```bash
error: bundling failed: Error: While trying to resolve module `@react-native-community/slider` from file `/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/combo/index.js`, the package `/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/@react-native-community/slider/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/@react-native-community/slider/index`. Indeed, none of these files exist:

  * `/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/@react-native-community/slider/index(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`
  * `/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/@react-native-community/slider/index/index(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`
    at ResolutionRequest.resolveDependency (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/node-haste/DependencyGraph/ResolutionRequest.js:65:15)
    at DependencyGraph.resolveDependency (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/node-haste/DependencyGraph.js:273:16)
    at Object.resolve (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/lib/transformHelpers.js:261:42)
    at dependencies.map.result (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/DeltaBundler/traverseDependencies.js:391:31)
    at Array.map (<anonymous>)
    at resolveDependencies (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/DeltaBundler/traverseDependencies.js:388:18)
    at /Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/DeltaBundler/traverseDependencies.js:261:33
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/DeltaBundler/traverseDependencies.js:87:24)
    at _next (/Users/karanthakkar/Work/Repos/Personal/react-native-gesture-handler/Example/node_modules/metro/src/DeltaBundler/traverseDependencies.js:107:9)
```

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

With this fix, the error no longer appears.