### PR TITLE
Update package.json to satisfy podspec checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@react-native-community/slider",
   "version": "1.0.2",
+  "license": "MIT",
+  "author": "react-native-community",
+  "homepage": "https://github.com/react-native-community/react-native-slider",
+  "description": "React Native component used to select a single value from a range of values.",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Summary:
---------

With the latest update to React-Native 0.59, the Slider component has been deprecated from react-native core and has been moved to this community package.

When adding the new `@react-native-community/slider` to a project that has a podfile– the `pod install` would not complete due to validation issues with the podspec file. https://github.com/react-native-community/react-native-slider/blob/master/react-native-slider.podspec

![image](https://user-images.githubusercontent.com/5051745/54240257-c9295800-44da-11e9-8025-5ea4c60a6a8a.png)

This should resolve the issue from #21 – I'm willing to bet as more people begin to upgrade to RN 0.59 today they will run across this issue.

Test Plan:
----------

This adds the missing fields to the package.json file so that the pod install can successfully run.

Cocoapods is still a bit of a pain-point in react-native development and will be improved in the coming months. https://github.com/react-native-community/discussions-and-proposals/issues/104

There's a chance you'll need to add `pod 'React'` if you notice that Cocoapods is automatically trying to install React@0.11.0 - see https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies for info there.

When all was said and done– my Podfile looked like this:

```
# Uncomment the next line to define a global platform for your project
platform :ios, '9.0'

target 'appname' do
  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
  # use_frameworks!

  # Pods for appname
  pod 'React', :path => '../node_modules/react-native', :subspecs => [
    'Core',
    'CxxBridge', # Include this for RN >= 0.47
    'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
    'RCTText',
    'RCTNetwork',
    'RCTWebSocket', # Needed for debugging
    'RCTAnimation', # Needed for FlatList and animations running on native UI thread
    # Add any other subspecs you want to use in your project
  ]
  # Explicitly include Yoga if you are using RN >= 0.42.0
  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
  
  # Third party deps podspec link
  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
  
  # Pod links from package.json
  pod 'react-native-slider', :path => '../node_modules/@react-native-community/slider'

  target 'appnameTests' do
    inherit! :search_paths
    # Pods for testing
  end

end
```
