### PR TITLE
chore: Fix typo in README for manual linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dependencies {
 On top, where imports are:
 
 ```java
-import com.reactnativecommunity.netinfo.ReactSliderPackage;
+import com.reactnativecommunity.slider.ReactSliderPackage;
 ```
 
 Add the `ReactSliderPackage` class to your list of exported packages.


### PR DESCRIPTION
Summary:
---------

Small typo in the README for the manual linking step on Android. Caught me out. netinfo -> slider

Test Plan:
----------
N/A