### PR TITLE
fix: Add missing default keyword to types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -103,5 +103,5 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
 */
 declare class SliderComponent extends React.Component<SliderProps> {}
 declare const SliderBase: ReactNative.Constructor<ReactNative.NativeMethodsMixin> & typeof SliderComponent;
-export class Slider extends SliderBase {}
+export default class Slider extends SliderBase {}
 export type SliderIOS = Slider;


### PR DESCRIPTION
Summary:
---------

Types are imported from react-native package, and Slider component don't have default export there, but in this community package usage is with it.

So default keyword missing from types, causing TS compile error:
`JSX element type 'Slider' does not have any construct or call signatures.`

PR fix this.


Test Plan:
----------

N/A