### PR TITLE
Use AndroidX support lib

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ repositories {
 
 dependencies {
   //noinspection GradleDynamicVersion
-  api "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+  api "androidx.appcompat:appcompat:${rootProject.ext.supportLibVersion}"
   api 'com.facebook.react:react-native:+'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,6 @@ ReactNativeSlider_compileSdkVersion=28
 ReactNativeSlider_buildToolsVersion=28.0.3
 ReactNativeSlider_targetSdkVersion=27
 ReactNativeSlider_minSdkVersion=16
+
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -8,7 +8,7 @@ package com.reactnativecommunity.slider;
 
 import android.content.Context;
 import android.os.Build;
-import android.support.v7.widget.AppCompatSeekBar;
+import androidx.appcompat.app.AppCompatSeekBar;
 import android.util.AttributeSet;
 import javax.annotation.Nullable;
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -135,7 +135,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "androidx.appcompat:appcompat:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation project(':react-native-slider')
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27
-        supportLibVersion = "28.0.0"
+        supportLibVersion = "1.0.2"
     }
     repositories {
         google()


### PR DESCRIPTION
Summary:
---------

Use AndroidX in place of legacy Android support libraries. This is required for any Android projects that use AndroidX for support libraries.

See: `https://developer.android.com/jetpack/androidx/migrate`

Specifically react-native-gesture-handler currently has a 4 PRs to migrate to AndroidX being blocked by this down stream dependency for our tests that require react-native-slider.