### PR TITLE
Add onSlidingStart prop on SliderProps interface in index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,6 +64,12 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
   minimumValue?: number;
 
   /**
+   * Callback that is called when the user picks up the slider.
+   * The initial value is passed as an argument to the callback handler.
+   */
+  onSlidingStart?: (value: number) => void;
+
+  /**
    * Callback called when the user finishes changing the value (e.g. when the slider is released).
    */
   onSlidingComplete?: (value: number) => void;


### PR DESCRIPTION
Summary:
---------

I use TypeScript to develop my react-native app. When I use `onSlidingStart` prop, I received a error message from transpiler, because of `onSlidingStart` prop definition is not contains in `typings/index.d.ts`. 
