### PR TITLE
Inverted slider android

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Check out the [example project](example) for more examples.
 - [`step`](#step)
 - [`maximumTrackTintColor`](#maximumtracktintcolor)
 - [`testID`](#testid)
-- [`inverted`](#inverted)
 - [`value`](#value)
+- [`inverted`](#inverted)
 - [`thumbTintColor`](#thumbtintcolor)
 - [`maximumTrackImage`](#maximumtrackimage)
 - [`minimumTrackImage`](#minimumtrackimage)
@@ -192,15 +192,6 @@ Used to locate this view in UI automation tests.
 
 ---
 
-### `inverted`
-Reverses the direction of the slider. Default value is false.
-
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
 ### `value`
 
 Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.
@@ -210,6 +201,15 @@ _This is not a controlled component_, you don't need to update the value during 
 | Type   | Required |
 | ------ | -------- |
 | number | No       |
+
+---
+
+### `inverted`
+Reverses the direction of the slider. Default value is false.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Check out the [example project](example) for more examples.
 - [`step`](#step)
 - [`maximumTrackTintColor`](#maximumtracktintcolor)
 - [`testID`](#testid)
+- [`inverted`](#inverted)
 - [`value`](#value)
 - [`thumbTintColor`](#thumbtintcolor)
 - [`maximumTrackImage`](#maximumtrackimage)
 - [`minimumTrackImage`](#minimumtrackimage)
 - [`thumbImage`](#thumbimage)
 - [`trackImage`](#trackimage)
-- [`inverted`](#inverted)
 
 ---
 
@@ -192,6 +192,15 @@ Used to locate this view in UI automation tests.
 
 ---
 
+### `inverted`
+Reverses the direction of the slider. Default value is false.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
+
+---
+
 ### `value`
 
 Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.
@@ -222,8 +231,6 @@ Assigns a maximum track image. Only static images are supported. The leftmost pi
 | ---------------------- | -------- | -------- |
 | Image.propTypes.source | No       | iOS      |
 
----
-
 ### `minimumTrackImage`
 
 Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track.
@@ -251,15 +258,6 @@ Assigns a single image for the track. Only static images are supported. The cent
 | Type                   | Required | Platform |
 | ---------------------- | -------- | -------- |
 | Image.propTypes.source | No       | iOS      |
-
----
-
-### `inverted`
-Reverses the direction of the slider. Default value is false.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
 
 ## Maintainers
 

--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -7,6 +7,7 @@
 
 package com.reactnativecommunity.slider;
 
+import android.os.Build;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
@@ -125,7 +126,17 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
   @Override
   protected ReactSlider createViewInstance(ThemedReactContext context) {
-    return new ReactSlider(context, null, STYLE);
+    ReactSlider slider = new ReactSlider(context, null, STYLE);
+    
+    if (Build.VERSION.SDK_INT >= 21) {
+      /** 
+       * Without this parameter the SeekBar progress line doesn't appear
+       * when it is rotated
+       */
+      slider.setSplitTrack(false);
+    }
+    
+    return slider;
   }
 
   @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
@@ -183,6 +194,15 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
       background.clearColorFilter();
     } else {
       background.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+    }
+  }
+  
+  @ReactProp(name = "inverted", defaultBoolean = false)
+  public void setInverted(ReactSlider view, boolean inverted) {
+    if (inverted) {
+      view.setRotation(180);
+    } else {
+      view.setRotation(0);
     }
   }
 

--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -130,8 +130,8 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     
     if (Build.VERSION.SDK_INT >= 21) {
       /** 
-       * Without this parameter the SeekBar progress line doesn't appear
-       * when it is rotated
+       * The "splitTrack" parameter should have "false" value,
+       * otherwise the SeekBar progress line doesn't appear when it is rotated.
        */
       slider.setSplitTrack(false);
     }

--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -199,11 +199,8 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   
   @ReactProp(name = "inverted", defaultBoolean = false)
   public void setInverted(ReactSlider view, boolean inverted) {
-    if (inverted) {
-      view.setRotation(180);
-    } else {
-      view.setRotation(0);
-    }
+    if (inverted) view.setScaleX(-1f);
+    else view.setScaleX(1f);
   }
 
   @Override

--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -193,7 +193,6 @@ exports.examples = [
   },
   {
     title: 'Inverted slider direction',
-    platform: 'ios',
     render(): React.Element<any> {
       return <SliderExample value={0.6} inverted />;
     },

--- a/js/Slider.js
+++ b/js/Slider.js
@@ -54,12 +54,6 @@ type IOSProps = $ReadOnly<{|
    * Sets an image for the thumb. Only static images are supported.
    */
   thumbImage?: ?ImageSource,
-
-  /**
-   * If true the slider will be inverted.
-   * Default value is false.
-   */
-  inverted?: ?boolean,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -146,6 +140,12 @@ type Props = $ReadOnly<{|
    * Used to locate this view in UI automation tests.
    */
   testID?: ?string,
+
+  /**
+   * If true the slider will be inverted.
+   * Default value is false.
+   */
+  inverted?: ?boolean,
 |}>;
 
 /**


### PR DESCRIPTION
Summary:
---------
I've added a "inverted" variable to slider for Android. It allows to invert the slider direction.
It fixes issue #39.

Also the issue #69 has been fixed.

Test Plan:
----------
Issue #39
You can set the "inverted" variable of a Slider component and it'll change its direction.
`<SliderExample inverted />`

![Screenshot 2019-08-30 at 13 20 56](https://user-images.githubusercontent.com/12548990/64107859-b9991680-cd7b-11e9-8dee-97a984f7d52e.png)
----------

Issue #69
You can check the fixed issue #69 with follow code:
(I've checked it in Android-s with API: 19, 24, 25, 28)

`<Slider style={{ width: 100, transform: [{ rotate: '-90deg' }] }} />`

![Screenshot 2019-08-30 at 15 59 12](https://user-images.githubusercontent.com/12548990/64107901-d2093100-cd7b-11e9-9c6e-88e6add0b175.png)

