### PR TITLE
feat: Implement thumbImage for Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -7,9 +7,22 @@
 package com.reactnativecommunity.slider;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
 import android.os.Build;
+
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.widget.AppCompatSeekBar;
+
 import android.util.AttributeSet;
+
+import java.net.URL;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import javax.annotation.Nullable;
 
 /**
@@ -111,5 +124,41 @@ public class ReactSlider extends AppCompatSeekBar {
 
   private double getStepValue() {
     return mStep > 0 ? mStep : mStepCalculated;
+  }
+
+  private BitmapDrawable getBitmapDrawable(final String uri) {
+    BitmapDrawable bitmapDrawable = null;
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Future<BitmapDrawable> future = executorService.submit(new Callable<BitmapDrawable>() {
+      @Override
+      public BitmapDrawable call() {
+        BitmapDrawable bitmapDrawable = null;
+        try {
+          Bitmap bitmap = BitmapFactory.decodeStream(new URL(uri).openStream());
+          bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+        return bitmapDrawable;
+      }
+    });
+    try {
+      bitmapDrawable = future.get();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return bitmapDrawable;
+  }
+
+  public void setThumbImage(final String uri) {
+    if (uri != null) {
+      setThumb(getBitmapDrawable(uri));
+      // Enable alpha channel for the thumbImage
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        setSplitTrack(false);
+      }
+    } else {
+      setThumb(getThumb());
+    }
   }
 }

--- a/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -14,20 +14,21 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.SeekBar;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
-import com.facebook.react.uimanager.ReactShadowNodeImpl;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@code ReactSlider}.
@@ -173,6 +174,15 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     } else {
       progress.setColorFilter(color, PorterDuff.Mode.SRC_IN);
     }
+  }
+
+  @ReactProp(name = "thumbImage")
+  public void setThumbImage(ReactSlider view, @Nullable ReadableMap source) {
+    String uri = null;
+    if (source != null) {
+      uri = source.getString("uri");
+    }
+    view.setThumbImage(uri);
   }
 
   @ReactProp(name = "maximumTrackTintColor", customType = "Color")

--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -167,7 +167,6 @@ exports.examples = [
   },
   {
     title: 'Custom thumb image',
-    platform: 'ios',
     render(): React.Element<any> {
       return <SliderExample thumbImage={require('./uie_thumb_big.png')} />;
     },

--- a/js/Slider.js
+++ b/js/Slider.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const React = require('react');
-const {Platform, StyleSheet} = require('react-native');
+const {Image, Platform, StyleSheet} = require('react-native');
 const RCTSliderNativeComponent = require('./RNCSliderNativeComponent');
 
 import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
@@ -49,11 +49,6 @@ type IOSProps = $ReadOnly<{|
    * leftmost pixel of the image will be stretched to fill the track.
    */
   maximumTrackImage?: ?ImageSource,
-
-  /**
-   * Sets an image for the thumb. Only static images are supported.
-   */
-  thumbImage?: ?ImageSource,
 
   /**
    * If true the slider will be inverted.
@@ -146,6 +141,11 @@ type Props = $ReadOnly<{|
    * Used to locate this view in UI automation tests.
    */
   testID?: ?string,
+
+  /**
+   * Sets an image for the thumb. Only static images are supported.
+   */
+  thumbImage?: ?ImageSource,
 |}>;
 
 /**
@@ -252,6 +252,7 @@ const Slider = (
   return (
     <RCTSliderNativeComponent
       {...localProps}
+      thumbImage={Image.resolveAssetSource(props.thumbImage)}
       ref={forwardedRef}
       style={style}
       onChange={onChangeEvent}

--- a/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -21,6 +21,7 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
       "height": 40,
     }
   }
+  thumbImage={null}
   thumbTintColor="green"
   value={0.5}
 />
@@ -45,6 +46,7 @@ exports[`<Slider /> renders disabled slider 1`] = `
       "height": 40,
     }
   }
+  thumbImage={null}
   value={0}
 />
 `;
@@ -68,6 +70,7 @@ exports[`<Slider /> renders enabled slider 1`] = `
       "height": 40,
     }
   }
+  thumbImage={null}
   value={0}
 />
 `;


### PR DESCRIPTION
Summary:
---------
This implements the `thumbImage` prop also for Android.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Changes were tested in both iOS and Android emulator, each in debug mode. This branch is also used in a production app, so it also works in release mode.

![Screenshot_1568126427](https://user-images.githubusercontent.com/222393/64623734-c821a680-d3e9-11e9-808c-e2121b2aaa27.png)


Regarding the thumbImage size for iOS: https://github.com/react-native-community/react-native-slider/issues/105

![Simulator Screen Shot - iPhone Xʀ - 2019-09-10 at 16 26 30](https://user-images.githubusercontent.com/222393/64622553-cce55b00-d3e7-11e9-8b96-e55c7d62335b.png)


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->