### PR TITLE
fix: use __dirname instead of unstable process.cwd in RN config file

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,4 +1,4 @@
-const root = process.cwd();
+const root = __dirname;
 
 module.exports = {
   dependencies: {


### PR DESCRIPTION
Summary:
---------

Yarn and `npx` differ in how they treat `process.cwd()`, with Yarn changing it to where the `yarn.lock` file is, and with `npx` not touching it (which also makes sense). To account for that, and for future CLI changes in this area, let's use `__dirname` (or path.resolve('.') but dirname is simpler), because this is the actual path we want the `root` to be resolved to.


Test Plan:
----------

Test example app