### PR TITLE
Fix missing thumbImage on android release mode

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -134,7 +134,17 @@ public class ReactSlider extends AppCompatSeekBar {
       public BitmapDrawable call() {
         BitmapDrawable bitmapDrawable = null;
         try {
-          Bitmap bitmap = BitmapFactory.decodeStream(new URL(uri).openStream());
+          Bitmap bitmap = null;
+          if (uri.startsWith("http://") || uri.startsWith("https://") ||
+              uri.startsWith("file://") || uri.startsWith("asset://") || uri.startsWith("data:")) {
+            bitmap = BitmapFactory.decodeStream(new URL(uri).openStream());
+          } else {
+            int drawableId = getResources()
+                .getIdentifier(uri, "drawable", getContext()
+                .getPackageName());
+            bitmap = BitmapFactory.decodeResource(getResources(), drawableId);
+          }
+
           bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
         } catch (Exception e) {
           e.printStackTrace();


### PR DESCRIPTION
## Summary
Fixes https://github.com/react-native-community/react-native-slider/issues/119

In debug mode RNs "Image.resolveAssetSource" method returns http-uri and in release mode that returns android resource name. Previously the case where it returns an android resource name was not handled.