### PR TITLE
docs: add run example scripts and contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,32 @@ Assigns a single image for the track. Only static images are supported. The cent
 | ---------------------- | -------- | -------- |
 | Image.propTypes.source | No       | iOS      |
 
+## Contributing
+
+While developing, you can run the [example app](/example/README.md) to test your changes.
+
+Make sure your code passes Flow, ESLint and the tests. Run the following to verify:
+
+```sh
+yarn validate:flow
+yarn validate:eslint
+yarn test:jest
+```
+or 
+
+```sh
+yarn test
+```
+to run them all.
+
+To fix formatting errors, run the following:
+
+```sh
+yarn validate:eslint --fix
+```
+
+Remember to cover your changes with tests if possible.
+
 ## Maintainers
 
 - [Michał Chudziak](https://github.com/michalchudziak) - [Callstack](https://callstack.com/)

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,6 @@
+# Run the example locally
+
+- Clone the repository 
+- Run `yarn` to install the dependencies
+- Checkout to this directory `cd example`
+- Run `yarn run:android` or `yarn run:ios` to start packager and the app

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,9 @@
   "name": "example",
   "version": "0.0.1",
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "run:android": "react-native run-android",
+    "run:ios": "react-native run-ios"
   },
   "dependencies": {
     "react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "workspaces": ["src", "example"],
   "scripts": {
-    "validate:eslint": "eslint src",
+    "validate:eslint": "eslint src example",
     "validate:flow": "flow check src",
     "test:jest": "jest src",
     "test": "yarn validate:eslint && yarn validate:flow && yarn test:jest"

--- a/src/package.json
+++ b/src/package.json
@@ -10,10 +10,6 @@
   },
   "main": "js/Slider.js",
   "types": "typings/index.d.ts",
-  "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
-    "start:android": "react-native run-android --root example/"
-  },
   "keywords": [
     "react-native",
     "react native",


### PR DESCRIPTION
Summary:
---------
Hi, I wanted to play around the package, but I had difficulties to run the example app. 
I decided to add proper scripts in `example` directory and add simple instructions for contributors.
I have written instructions in a similar manner as in `react-native-tab-view` repo.

Test Plan:
----------

1. Read added docs and verify if they are correct and useful.
2. Test if added scripts work.