### PR TITLE
add instructions to link the native code for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ and install cocoapods
 
 `pod install`
 
+and link the native code for android
+
+`react-native link @react-native-community/slider`
+
 ## React Native Compatibility
 To use this library you need to ensure you are using the correct version of React Native.
 


### PR DESCRIPTION
Summary:
---------

Need to link the library to use it in ejected android apps and for developers not using 'pod' (or developing on windows)
If the README contains instructions/ commands for pod(iOS), why no instructions for android ?

Test Plan:
----------

Had to refer to this issue and discussion to resolve my error
https://github.com/react-native-community/react-native-slider/issues/41#issuecomment-486139196