### PR TITLE
Android: Apply slider padding from css

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
@@ -30,6 +31,7 @@ import com.facebook.yoga.YogaNode;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+import android.content.res.Resources;
 
 /**
  * Manages instances of {@code ReactSlider}.
@@ -211,6 +213,33 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   public void setInverted(ReactSlider view, boolean inverted) {
     if (inverted) view.setScaleX(-1f);
     else view.setScaleX(1f);
+  }
+
+
+  public static int dpToPx(int dp) {
+    return (int) (dp * Resources.getSystem().getDisplayMetrics().density);
+  }
+  
+  public static int pxToDp(int px) {
+    return (int) (px / Resources.getSystem().getDisplayMetrics().density);
+  }
+
+  @ReactPropGroup(names = {
+      ViewProps.PADDING,
+      ViewProps.PADDING_LEFT,
+      ViewProps.PADDING_TOP,
+      ViewProps.PADDING_RIGHT,
+      ViewProps.PADDING_BOTTOM,
+    }, customType = "Style")
+  public void setStyle(ReactSlider view, int index, Integer value) {
+    value = dpToPx(value);
+    if(index == 0) {
+      view.setPadding(value, value, value, value);
+    } else {
+      int array[] = {view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), view.getPaddingBottom()};
+      array[index - 1] = value;
+      view.setPadding(array[0], array[1], array[2], array[3]);
+    }
   }
 
   @Override


### PR DESCRIPTION
Summary:
---------

This PR applies the padding information from the CSS style associated to the Slider component.

This can be useful when you need to add some overlay on the slider.

**NOTE**: I did not add the support for IOS. Maybe someone could help with this.

Test Plan:
----------
```
<Slider
    ...
    style={{paddingLeft: 10, paddingRight: 10}}
    />
```
or
```
<Slider
    ...
    style={{padding: 10}}
    />
```

