### PR TITLE
Add accessibility improvements for screen readers

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -12,9 +12,9 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.SeekBar;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -27,8 +27,9 @@ import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -211,6 +212,21 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   public void setInverted(ReactSlider view, boolean inverted) {
     if (inverted) view.setScaleX(-1f);
     else view.setScaleX(1f);
+  }
+
+  @ReactProp(name = "accessibilityUnits")
+  public void setAccessibilityUnits(ReactSlider view, String accessibilityUnits) {
+    view.setAccessibilityUnits(accessibilityUnits);
+  }
+
+  @ReactProp(name = "accessibilityIncrements")
+  public void setAccessibilityIncrements(ReactSlider view, ReadableArray accessibilityIncrements) {
+    List objectList = accessibilityIncrements.toArrayList();
+    List<String> stringList = new ArrayList<>();
+    for(Object item: objectList) {
+      stringList.add((String)item);
+    }
+    view.setAccessibilityIncrements(stringList);
   }
 
   @Override

--- a/src/ios/RNCSlider.h
+++ b/src/ios/RNCSlider.h
@@ -21,8 +21,8 @@
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;
 @property (nonatomic, strong) UIImage *maximumTrackImage;
-
 @property (nonatomic, strong) UIImage *thumbImage;
-
+@property (nonatomic, strong) NSString *accessibilityUnits;
+@property (nonatomic, strong) NSArray *accessibilityIncrements;
 
 @end

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -21,12 +21,30 @@
 {
   _unclippedValue = value;
   super.value = value;
+  [self setupAccessibility:value];
 }
 
 - (void)setValue:(float)value animated:(BOOL)animated
 {
   _unclippedValue = value;
   [super setValue:value animated:animated];
+  [self setupAccessibility:value];
+}
+
+- (void)setupAccessibility:(float)value
+{
+  if (self.accessibilityUnits && self.accessibilityIncrements && [self.accessibilityIncrements count] - 1 == (int)self.maximumValue) {
+    int index = (int)value;
+    NSString *sliderValue = (NSString *)[self.accessibilityIncrements objectAtIndex:index];
+    NSUInteger stringLength = [self.accessibilityUnits length];
+
+    NSString *spokenUnits = [NSString stringWithString:self.accessibilityUnits];
+    if (sliderValue && [sliderValue intValue] == 1) {
+      spokenUnits = [spokenUnits substringToIndex:stringLength-1];
+    }
+    
+    self.accessibilityValue = [NSString stringWithFormat:@"%@ %@", sliderValue, spokenUnits];
+  }
 }
 
 - (void)setMinimumValue:(float)minimumValue
@@ -104,7 +122,8 @@
   }
 }
 
-- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
+{
     return YES;
 }
 

--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -99,6 +99,9 @@ RCT_EXPORT_VIEW_PROPERTY(onRNCSliderSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);
+RCT_EXPORT_VIEW_PROPERTY(accessibilityIncrements, NSArray);
+
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RNCSlider)
 {
   if (json) {

--- a/src/js/RNCSliderNativeComponent.js
+++ b/src/js/RNCSliderNativeComponent.js
@@ -27,6 +27,8 @@ type Event = SyntheticEvent<
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
+  accessibilityUnits?: string,
+  accessibilityIncrements?: Array<string>,
   disabled?: ?boolean,
   enabled?: ?boolean,
   inverted?: ?boolean,

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -147,6 +147,22 @@ type Props = $ReadOnly<{|
    * Default value is false.
    */
   inverted?: ?boolean,
+
+  /**
+   * A string of one or more words to be announced by the screen reader.
+   * Otherwise, it will announce the value as a percentage.
+   * Requires passing a value to `accessibilityIncrements` to work correctly.
+   * Should be a plural word, as singular units will be handled.
+   */
+  accessibilityUnits?: string,
+
+  /**
+   * An array of values that represent the different increments displayed
+   * by the slider. All the values passed into this prop must be strings.
+   * Requires passing a value to `accessibilityUnits` to work correctly.
+   * The number of elements must be the same as `maximumValue`.
+   */
+  accessibilityIncrements?: Array<string>,
 |}>;
 
 /**

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -108,6 +108,21 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
    */
   inverted?: boolean;
 
+  /**
+   * A string of one or more words to be announced by the screen reader.
+   * Otherwise, it will announce the value as a percentage.
+   * Requires passing a value to `accessibilityIncrements` to work correctly.
+   * Should be a plural word, as singular units will be handled.
+   */
+  accessibilityUnits?: string;
+
+  /**
+   * A string of one or more words to be announced by the screen reader.
+   * Otherwise, it will announce the value as a percentage.
+   * Requires passing a value to `accessibilityIncrements` to work correctly.
+   * Should be a plural word, as singular units will be handled.
+   */
+  accessibilityIncrements?: Array<string>;
 }
 
 /**


### PR DESCRIPTION
Summary:
---------
Add accessibility improvements for screen readers to announce custom units.

Currently there are no capabilities for custom screen reader output with this component. This PR would allow consumers to specify a custom unit to be read by the screen reader, instead of just the default `percent` value. It is an optional field, so if nothing is specified it will use the default behavior.
There is one minor caveat:
- On iOS everything is overridden as expected
- On Android, the default values are still announced, along with the additional custom values. This seems to be due to some limitations of accessibility in RN 61, and the `ReactAccessibilityDelegate`


Test Plan:
----------
I tested this by replacing the yarn library with my local copy in my existing application, that I work on full-time. Doing the same with an example application should work fine, but this requires having a physical device available. The changes should be
- On accessibility focus, the screen reader announces the current value of the slider with the custom units that were specified
- On value update, the screen reader announces the updated value of the slider with the custom units that were specified
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->