### PR TITLE
Fix regression from #186

### DIFF
--- a/src/js/RNCSliderNativeComponent.web.js
+++ b/src/js/RNCSliderNativeComponent.web.js
@@ -267,7 +267,7 @@ const RCTSliderWebComponent = React.forwardRef(
         );
         if (value !== withinBounds) {
           setValue(withinBounds);
-          onValueChange(value);
+          onValueChange(withinBounds);
         }
       },
       [minimumValue, maximumValue, value, onValueChange],


### PR DESCRIPTION
Summary:
---------

A regression was introduced in PR #186 
https://github.com/react-native-community/react-native-slider/pull/186/files#diff-5847c2317e1d89fb73fd4d87ff989ce6R253

where 
`onValueChange(withinBounds);`
became
`onValueChange(value);`

Therefore value is not correctly changed, preventing to reach min and max values

Test Plan:
----------
Test with a slider from 0 to 100 (%) with step of 1.
Trying to slide to min and max.

**Before**
![image](https://user-images.githubusercontent.com/431119/84256925-e3564980-ab14-11ea-9f8d-ec8ef90eb187.png)
![image](https://user-images.githubusercontent.com/431119/84257032-02ed7200-ab15-11ea-9988-f075d84a2339.png)

Cannot reach 0 and 100

**After**
![image](https://user-images.githubusercontent.com/431119/84257064-14367e80-ab15-11ea-846e-1bd788db4660.png)
![image](https://user-images.githubusercontent.com/431119/84257077-1bf62300-ab15-11ea-90f9-2e6f36977f82.png)

Able to reach 0 and 100