### PR TITLE
docs: fix links of color in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The color used for the track to the left of the button. Overrides the default bl
 
 | Type               | Required |
 | ------------------ | -------- |
-| [color](colors.md) | No       |
+| [color](https://reactnative.dev/docs/colors) | No       |
 
 ---
 
@@ -185,7 +185,7 @@ The color used for the track to the right of the button. Overrides the default g
 
 | Type               | Required |
 | ------------------ | -------- |
-| [color](colors.md) | No       |
+| [color](https://reactnative.dev/docs/colors) | No       |
 
 ---
 
@@ -226,7 +226,7 @@ Color of the foreground switch grip.
 
 | Type               | Required | Platform |
 | ------------------ | -------- | -------- |
-| [color](colors.md) | No       | Android  |
+| [color](https://reactnative.dev/docs/colors) | No       | Android  |
 
 ---
 


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

The link of color should point to ReactNative's document.
Currently, the link points to a 404 page.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

No test.