### PR TITLE
Re add ios tap handler

### DIFF
--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -31,6 +31,7 @@ class SliderExample extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
         <Slider
           {...this.props}
           onValueChange={value => this.setState({value: value})}
+          onSlidingComplete={value => this.setState({value: value})}
         />
       </View>
     );

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -23,9 +23,12 @@
     }
     return self;
 }
+
 - (void)tapHandler:(UITapGestureRecognizer *)gesture {
     CGPoint touchPoint = [gesture locationInView:self];
-    [self setValue:touchPoint.x / self.bounds.size.width animated: YES];
+    float rangeWidth = self.maximumValue - self.minimumValue;
+    float sliderPercent = touchPoint.x / self.bounds.size.width;
+    [self setValue:self.minimumValue + (rangeWidth * sliderPercent) animated: YES];
 }
 
 - (void)setValue:(float)value

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -10,11 +10,22 @@
 @implementation RNCSlider
 {
   float _unclippedValue;
+  UITapGestureRecognizer * tapGesturer;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    return [super initWithFrame:frame];
+    self = [super initWithFrame:frame];
+    if (self) {
+        tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
+        [tapGesturer setNumberOfTapsRequired: 1];
+        [self addGestureRecognizer:tapGesturer];
+    }
+    return self;
+}
+- (void)tapHandler:(UITapGestureRecognizer *)gesture {
+    CGPoint touchPoint = [gesture locationInView:self];
+    [self setValue:touchPoint.x / self.bounds.size.width animated: YES];
 }
 
 - (void)setValue:(float)value


### PR DESCRIPTION
Summary:
---------

First thanks for this package everyone, I appreciate it

I want the slider on iOS to handle tap events by sliding to the tap.

It's been tried before: #117 implemented tap-handling for iOS, and it worked, mostly

But: #131 #134 were documented regressions from #117

So #136 reverted the change from #117 as the understandable quick fix

I investigated the original PR because I really wanted it to work, and discovered that it was just a mis-match between the values the tap handler propagated compared with what the value consumer wanted

Specifically:
- value emitted was pure 0 through 1 inclusive percentage where the slider was tapped
- value consumed was expected to be the range value from minimum to maximum

So:
- I reverted the revert from #136 / @michalchudziak 
- That brings us back to the #117 state where we have tap-handling from @shwetsolanki but with a bug
- I altered the math in the tap handler to take the original raw slider percentage and emit instead the range value

Now it works?

Test Plan:
----------

1. First just hacking around I tested this in my project directly with a node_modules edit, it worked! For positive min/max and a 1 step value it was perfect
1. Then I forked and cloned and checked it in the example - it didn't work! 
1. So I added onSlideComplete handling in the example and now it worked everywhere except negative min value
1. So I corrected the math to handle negatives (similar to existing code)

Now it works everywhere I believe.
Interested parties that should test if/when this is integrated are @schumannd @ludovic-gonthier and @mcousillas6  and @BunlongOung

I will attach a patch-package file in a follow-on comment that you can drop in patch-package for use with the current published version in order to easily verify. I would love any success (or error) reports

Cheers