### PR TITLE
share ref with update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Check out the [example project](example) for more examples.
 - [`minimumTrackImage`](#minimumtrackimage)
 - [`thumbImage`](#thumbimage)
 - [`trackImage`](#trackimage)
+- [`ref`](#ref)
 
 ---
 
@@ -265,6 +266,16 @@ Assigns a single image for the track. Only static images are supported. The cent
 | Type                   | Required | Platform |
 | ---------------------- | -------- | -------- |
 | Image.propTypes.source | No       | iOS      |
+
+---
+
+### `ref`
+
+Reference object.
+
+| Type             | Required | Platform |
+| -----------------| -------- | -------- |
+| MutableRefObject | No       | web      |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Assigns a single image for the track. Only static images are supported. The cent
 Reference object.
 
 | Type             | Required | Platform |
-| -----------------| -------- | -------- |
+| ---------------- | -------- | -------- |
 | MutableRefObject | No       | web      |
 
 ## Contributing

--- a/src/js/RNCSliderNativeComponent.web.js
+++ b/src/js/RNCSliderNativeComponent.web.js
@@ -313,7 +313,7 @@ const RCTSliderWebComponent = React.forwardRef(
     React.useImperativeHandle(
       forwardedRef,
       () => ({
-        updateValue: (val) => {
+        updateValue: val => {
           updateValue(val);
         },
       }),

--- a/src/js/RNCSliderNativeComponent.web.js
+++ b/src/js/RNCSliderNativeComponent.web.js
@@ -310,6 +310,16 @@ const RCTSliderWebComponent = React.forwardRef(
       }
     };
 
+    React.useImperativeHandle(
+      forwardedRef,
+      () => ({
+        updateValue: (val) => {
+          updateValue(val);
+        },
+      }),
+      [updateValue],
+    );
+
     return (
       <View
         ref={containerRef}
@@ -347,7 +357,7 @@ function calculatePrecision(minimumValue, maximumValue, step) {
   } else {
     // Calculate the number of decimals we can encounter in the results
     const decimals = [minimumValue, maximumValue, step].map(
-      value => ((value + '').split('.').pop() || '').length,
+      (value) => ((value + '').split('.').pop() || '').length,
     );
     return Math.max(...decimals);
   }

--- a/src/js/RNCSliderNativeComponent.web.js
+++ b/src/js/RNCSliderNativeComponent.web.js
@@ -357,7 +357,7 @@ function calculatePrecision(minimumValue, maximumValue, step) {
   } else {
     // Calculate the number of decimals we can encounter in the results
     const decimals = [minimumValue, maximumValue, step].map(
-      (value) => ((value + '').split('.').pop() || '').length,
+      value => ((value + '').split('.').pop() || '').length,
     );
     return Math.max(...decimals);
   }

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -8,6 +8,10 @@ export interface SliderPropsAndroid extends ReactNative.ViewProps {
   thumbTintColor?: string;
 }
 
+export interface SliderRef {
+  updateValue(value: number): void;
+}
+
 export interface SliderPropsIOS extends ReactNative.ViewProps {
   /**
    * Assigns a maximum track image. Only static images are supported.
@@ -123,6 +127,11 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
    * Should be a plural word, as singular units will be handled.
    */
   accessibilityIncrements?: Array<string>;
+
+  /**
+   * Reference object.
+   */
+  ref: React.MutableRefObject<SliderRef>;
 }
 
 /**


### PR DESCRIPTION
## Describe the Feature
Allow to control of value by ref (only for web version so far).

## Possible Implementations
`ref.current.updateValue(value: number)`

## Related issue
https://github.com/react-native-community/react-native-slider/issues/205