### PR TITLE
Match step values when setting value after tap gesture.

### DIFF
--- a/src/ios/RNCSlider.h
+++ b/src/ios/RNCSlider.h
@@ -25,4 +25,6 @@
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;
 
+- (void)setValue:(float)value animated:(BOOL)animated matchingSteps:(BOOL)matchingSteps;
+
 @end

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -28,7 +28,25 @@
     CGPoint touchPoint = [gesture locationInView:self];
     float rangeWidth = self.maximumValue - self.minimumValue;
     float sliderPercent = touchPoint.x / self.bounds.size.width;
-    [self setValue:self.minimumValue + (rangeWidth * sliderPercent) animated: YES];
+    
+    float value = self.minimumValue + (rangeWidth * sliderPercent);
+    [self setValue:value animated:YES matchingSteps:YES];
+
+    self.onRNCSliderValueChange(@{
+        @"value": @(self.value),
+    });
+}
+
+- (void)setValue:(float)value animated:(BOOL)animated matchingSteps:(BOOL)matchingSteps {
+    if ( matchingSteps ) {
+        value = MAX(self.minimumValue,
+          MIN(self.maximumValue,
+            self.minimumValue + round((value - self.minimumValue) / self.step) * self.step
+          )
+        );
+    }
+    
+    [self setValue:value animated:animated];
 }
 
 - (void)setValue:(float)value

--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -32,41 +32,32 @@ RCT_EXPORT_MODULE()
 
 static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidingStart)
 {
-  float value = sender.value;
-
   if (sender.step > 0 &&
       sender.step <= (sender.maximumValue - sender.minimumValue)) {
 
-    value =
-      MAX(sender.minimumValue,
-        MIN(sender.maximumValue,
-          sender.minimumValue + round((sender.value - sender.minimumValue) / sender.step) * sender.step
-        )
-      );
-
-    [sender setValue:value animated:NO];
+    [sender setValue:sender.value animated:NO matchingSteps:YES];
   }
 
   if (continuous) {
-    if (sender.onRNCSliderValueChange && sender.lastValue != value) {
+    if (sender.onRNCSliderValueChange && sender.lastValue != sender.value) {
       sender.onRNCSliderValueChange(@{
-        @"value": @(value),
+        @"value": @(sender.value),
       });
     }
   } else {
     if (sender.onRNCSliderSlidingComplete && !isSlidingStart) {
       sender.onRNCSliderSlidingComplete(@{
-        @"value": @(value),
+        @"value": @(sender.value),
       });
     }
       if (sender.onRNCSliderSlidingStart && isSlidingStart) {
         sender.onRNCSliderSlidingStart(@{
-          @"value": @(value),
+          @"value": @(sender.value),
         });
       }
   }
 
-  sender.lastValue = value;
+  sender.lastValue = sender.value;
 }
 
 - (void)sliderValueChanged:(RNCSlider *)sender


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

The changes from PRs #117 and #136 do not fire value changed events on iOS.
This PR changes that. In addition, step values are now fixed so that clicking in between steps actually sends a valid value in the step range defined by the consumer of this package.


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I tested it in the live app I am working on. We have steps of 1. I can now click anywhere and always get a valid value in my JS-callback.