### PR TITLE
Refactored inline style to address eslint warning.

### DIFF
--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -30,7 +30,7 @@ class SliderExample extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
         </Text>
         <Slider
           step={0.5}
-          style={{width: 300, opacity: 1, height: 50, marginTop: 50}}
+          style={styles.slider}
           {...this.props}
           onValueChange={value => this.setState({value: value})}
         />
@@ -100,6 +100,12 @@ class SlidingCompleteExample extends React.Component<
 }
 
 const styles = StyleSheet.create({
+  slider: {
+    width: 300,
+    opacity: 1,
+    height: 50,
+    marginTop: 50,
+  },
   text: {
     fontSize: 14,
     textAlign: 'center',


### PR DESCRIPTION
Summary:
---------

Seemed a shame to have validate:eslint marred by a warning, so threw the inline style in to StyleSheet.create.


Test Plan:
----------

`npx yarn test` in example directory passes.
Verified example app visually on iOS and Android emulators.
