### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/src/react-native-slider.podspec
+++ b/src/react-native-slider.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-slider.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

One of the projects I'm working on stopped working after updating xcode to latest version. I've found that Xcode 12 fails to build if a module depends on React instead of React-Core. 
Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116
This requires RN 0.60.2 or newer.

Test Plan:
----------

Unfortunately, I was unable to run example even after fixing `jscallinvoker`issue. However, all of my projects that use this module started working on xcode 12 after patching the podspec to use React-Core.