### PR TITLE
Add tapToSeek prop, fix unintentional scrolling, call onValueChanged when tapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Check out the [example project](example) for more examples.
 - [`testID`](#testid)
 - [`value`](#value)
 - [`inverted`](#inverted)
+- [`tapToSeek`](#tapToSeek)
 - [`vertical`](#vertical)
 - [`thumbTintColor`](#thumbtintcolor)
 - [`maximumTrackImage`](#maximumtrackimage)
@@ -212,6 +213,15 @@ _This is not a controlled component_, you don't need to update the value during 
 | Type   | Required |
 | ------ | -------- |
 | number | No       |
+
+---
+
+### `tapToSeek`
+Permits tapping on the slider track to set the thumb position. Defaults to false on iOS. No effect on Android or Windows.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
 
 ---
 

--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -131,9 +131,12 @@ export const examples = [
     },
   },
   {
-    title: 'step: 0.25',
+    title: 'step: 0.25, tap to seek on iOS',
     render(): Element<any> {
-      return <SliderExample step={0.25} />;
+      return <SliderExample
+        step={0.25}
+        tapToSeek={true}
+      />;
     },
   },
   {

--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -133,10 +133,7 @@ export const examples = [
   {
     title: 'step: 0.25, tap to seek on iOS',
     render(): Element<any> {
-      return <SliderExample
-        step={0.25}
-        tapToSeek={true}
-      />;
+      return <SliderExample step={0.25} tapToSeek={true} />;
     },
   },
   {

--- a/src/ios/RNCSlider.h
+++ b/src/ios/RNCSlider.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong) UIImage *minimumTrackImage;
 @property (nonatomic, strong) UIImage *maximumTrackImage;
 @property (nonatomic, strong) UIImage *thumbImage;
+@property (nonatomic, assign) bool tapToSeek;
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;
 

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -10,25 +10,11 @@
 @implementation RNCSlider
 {
   float _unclippedValue;
-  UITapGestureRecognizer * tapGesturer;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
-        [tapGesturer setNumberOfTapsRequired: 1];
-        [self addGestureRecognizer:tapGesturer];
-    }
-    return self;
-}
-
-- (void)tapHandler:(UITapGestureRecognizer *)gesture {
-    CGPoint touchPoint = [gesture locationInView:self];
-    float rangeWidth = self.maximumValue - self.minimumValue;
-    float sliderPercent = touchPoint.x / self.bounds.size.width;
-    [self setValue:self.minimumValue + (rangeWidth * sliderPercent) animated: YES];
+    return [super initWithFrame:frame];
 }
 
 - (void)setValue:(float)value
@@ -134,11 +120,6 @@
   } else {
     self.transform = CGAffineTransformMakeScale(1, 1);
   }
-}
-
-- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    return YES;
 }
 
 @end

--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -11,6 +11,7 @@
 #import <React/RCTEventDispatcher.h>
 #import "RNCSlider.h"
 #import <React/UIView+React.h>
+#import "os/log.h"
 
 @implementation RNCSliderManager
 
@@ -27,25 +28,64 @@ RCT_EXPORT_MODULE()
    forControlEvents:(UIControlEventTouchUpInside |
                      UIControlEventTouchUpOutside |
                      UIControlEventTouchCancel)];
+
+  UITapGestureRecognizer *tapGesturer;
+  tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
+  [tapGesturer setNumberOfTapsRequired: 1];
+  [slider addGestureRecognizer:tapGesturer];
+
   return slider;
+}
+
+- (void)tapHandler:(UITapGestureRecognizer *)gesture {
+  // Bail out if the source view of the gesture isn't an RNCSlider.
+  if ([gesture.view class] != [RNCSlider class]) {
+    return;
+  }
+  RNCSlider *slider = (RNCSlider *)gesture.view;
+
+  CGPoint touchPoint = [gesture locationInView:slider];
+  float rangeWidth = slider.maximumValue - slider.minimumValue;
+  float sliderPercent = touchPoint.x / slider.bounds.size.width;
+  float value = slider.minimumValue + (rangeWidth * sliderPercent);
+
+  [slider setValue:discreteValue(slider, value) animated: YES];
+  
+  // Trigger onValueChange to address https://github.com/react-native-community/react-native-slider/issues/212
+  if (slider.onRNCSliderValueChange) {
+    slider.onRNCSliderValueChange(@{
+      @"value": @(slider.value),
+    });
+  }
+
+  if (slider.onRNCSliderSlidingComplete) {
+    slider.onRNCSliderSlidingComplete(@{
+      @"value": @(slider.value),
+    });
+  }
+}
+
+static float discreteValue(RNCSlider *sender, float value) {
+  // If step is set and less than or equal to difference between max and min values,
+  // pick the closest discrete multiple of step to return.
+  if (sender.step > 0 && sender.step <= (sender.maximumValue - sender.minimumValue)) {
+    return
+      MAX(sender.minimumValue,
+        MIN(sender.maximumValue,
+          sender.minimumValue + round((value - sender.minimumValue) / sender.step) * sender.step
+        )
+      );
+  }
+
+  // Otherwise, leave value unchanged.
+  return value;
 }
 
 static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidingStart)
 {
-  float value = sender.value;
+  float value = discreteValue(sender, sender.value);
 
-  if (sender.step > 0 &&
-      sender.step <= (sender.maximumValue - sender.minimumValue)) {
-
-    value =
-      MAX(sender.minimumValue,
-        MIN(sender.maximumValue,
-          sender.minimumValue + round((sender.value - sender.minimumValue) / sender.step) * sender.step
-        )
-      );
-
-    [sender setValue:value animated:NO];
-  }
+  [sender setValue:value animated:NO];
 
   if (continuous) {
     if (sender.onRNCSliderValueChange && sender.lastValue != value) {

--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -44,6 +44,10 @@ RCT_EXPORT_MODULE()
   }
   RNCSlider *slider = (RNCSlider *)gesture.view;
 
+  if (!slider.tapToSeek) {
+    return;
+  }
+
   CGPoint touchPoint = [gesture locationInView:slider];
   float rangeWidth = slider.maximumValue - slider.minimumValue;
   float sliderPercent = touchPoint.x / slider.bounds.size.width;
@@ -139,6 +143,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRNCSliderSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(tapToSeek, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityIncrements, NSArray);
 

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -309,6 +309,7 @@ SliderWithRef.defaultProps = {
   maximumValue: 1,
   step: 0,
   inverted: false,
+  tapToSeek: false,
 };
 
 let styles;

--- a/src/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/src/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -21,6 +21,7 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
       "height": 40,
     }
   }
+  tapToSeek={false}
   thumbImage={null}
   thumbTintColor="green"
   value={0.5}
@@ -46,6 +47,7 @@ exports[`<Slider /> renders disabled slider 1`] = `
       "height": 40,
     }
   }
+  tapToSeek={false}
   thumbImage={null}
   value={0}
 />
@@ -70,6 +72,7 @@ exports[`<Slider /> renders enabled slider 1`] = `
       "height": 40,
     }
   }
+  tapToSeek={false}
   thumbImage={null}
   value={0}
 />


### PR DESCRIPTION
Summary:
---------

This feature fork started out adding a tapToSeek prop to allow us to disable that functionality on iOS. The main motivation for this was to avoid inadvertent scrolling on touch down on iOS. Found what may be causing the inadvertent scrolling and fixed that (simulator only unfortunately - I don't a physical device). Also added the originally requested tapToSeek prop to make this functionality opt in on iOS.

Believe this fixes #156, fixes #211, fixes #212 and maybe fixes #147 as well.

Test Plan:
----------

Locally run yarn test passes.
CircleCI tests pass.
Visually inspect on iOS simulator and Android emulator. 
Tweaked one of the examples to demonstrate the tapToSeek behaviour.
